### PR TITLE
Return default objects instead of undefined

### DIFF
--- a/src/mixins/__tests__/element.spec.js
+++ b/src/mixins/__tests__/element.spec.js
@@ -7,6 +7,15 @@ const AlchemyElementComponent = {
 }
 
 describe("Alchemy element mixin", () => {
+  it("without element has default object", () => {
+    const comp = shallowMount(AlchemyElementComponent, {
+      propsData: {
+        element: undefined,
+      },
+    })
+    expect(comp.vm.element).toEqual({ essences: [] })
+  })
+
   it("has access to the element", () => {
     const element = {
       name: "content_page",
@@ -31,7 +40,7 @@ describe("Alchemy element mixin", () => {
             },
           },
         })
-        expect(comp.vm.getEssence("foo")).toBeUndefined()
+        expect(comp.vm.getEssence("foo")).toEqual({})
       })
     })
 
@@ -87,11 +96,11 @@ describe("Alchemy element mixin", () => {
       it.skip("scrolls element into view", () => {
         const comp = shallowMount(AlchemyElementComponent, {
           propsData: {
-            element: {}
+            element: {},
           },
           mocks: {
-            $el: {}
-          }
+            $el: {},
+          },
         })
         const spy = jest.spyOn(comp.vm.$el, "scrollIntoView")
         comp.vm.focusAlchemyElement(1001)

--- a/src/mixins/__tests__/page.spec.js
+++ b/src/mixins/__tests__/page.spec.js
@@ -24,6 +24,15 @@ const AlchemyPageComponent = {
 }
 
 describe("Alchemy page mixin", () => {
+  it("without page has default object", () => {
+    const comp = shallowMount(AlchemyPageComponent, {
+      propsData: {
+        page: undefined,
+      },
+    })
+    expect(comp.vm.page).toEqual({ elements: [] })
+  })
+
   it("has access to the page", () => {
     const page = {
       page_layout: "content_page",
@@ -38,7 +47,7 @@ describe("Alchemy page mixin", () => {
   })
 
   describe("elementByName", () => {
-    describe("if element exists", () =>{
+    describe("if element exists", () => {
       it("returns element", () => {
         const element = { name: "header" }
         const component = shallowMount(AlchemyPageComponent, {
@@ -49,12 +58,11 @@ describe("Alchemy page mixin", () => {
           },
         })
         expect(component.vm.elementByName("header")).toEqual(element)
-
       })
     })
 
-    describe("if element does not exist", () =>{
-      it("returns undefined", () => {
+    describe("if element does not exist", () => {
+      it("returns empty object", () => {
         const component = shallowMount(AlchemyPageComponent, {
           propsData: {
             page: {
@@ -62,13 +70,13 @@ describe("Alchemy page mixin", () => {
             },
           },
         })
-        expect(component.vm.elementByName("foo")).toBeUndefined()
+        expect(component.vm.elementByName("foo")).toEqual({})
       })
     })
   })
 
   describe("elementsByName", () => {
-    describe("if element exists", () =>{
+    describe("if element exists", () => {
       it("returns element", () => {
         const elements = [{ name: "header" }]
         const component = shallowMount(AlchemyPageComponent, {
@@ -79,11 +87,10 @@ describe("Alchemy page mixin", () => {
           },
         })
         expect(component.vm.elementsByName("header")).toEqual(elements)
-
       })
     })
 
-    describe("if element does not exist", () =>{
+    describe("if element does not exist", () => {
       it("returns undefined", () => {
         const component = shallowMount(AlchemyPageComponent, {
           propsData: {

--- a/src/mixins/element.js
+++ b/src/mixins/element.js
@@ -13,7 +13,7 @@ export default {
             message: "Alchemy.focusElementEditor",
             element_id: this.element.id,
           },
-          "*",
+          "*"
         )
       })
     }
@@ -29,16 +29,21 @@ export default {
       }
     },
     getIngredient(name) {
-      return this.getEssence(name)?.ingredient
+      return this.getEssence(name).ingredient
     },
     getEssence(name) {
-      return this.element.essences.find((e) => e.role === name)
+      return this.element.essences.find((e) => e.role === name) || {}
     },
   },
   props: {
     element: {
       type: Object,
       required: true,
+      default() {
+        return {
+          essences: [],
+        }
+      },
     },
   },
 }

--- a/src/mixins/page.js
+++ b/src/mixins/page.js
@@ -6,6 +6,11 @@ export default {
     page: {
       type: Object,
       required: true,
+      default() {
+        return {
+          elements: [],
+        }
+      },
     },
   },
   methods: {
@@ -17,7 +22,7 @@ export default {
       return "FallbackElement"
     },
     elementByName(name) {
-      return this.elementsByName(name)[0]
+      return this.elementsByName(name)[0] || {}
     },
     elementsByName(name) {
       return this.page.elements.filter((e) => e.name === name)


### PR DESCRIPTION
In case of an object is undefined we return a default object
the component can work with (aka. has essences or elements).

Return an empty object instead of undefined if essence or element
cannot be found.

Helps prevent unknown property errors during render