### PR TITLE
Add componentName helper to Element mixin

### DIFF
--- a/src/mixins/element.js
+++ b/src/mixins/element.js
@@ -34,6 +34,13 @@ export default {
     getEssence(name) {
       return this.element.essences.find((e) => e.role === name) || {}
     },
+    componentName(element) {
+      const name = element.name
+      if (this.$options.components[name]) {
+        return name
+      }
+      return "FallbackElement"
+    },
   },
   props: {
     element: {


### PR DESCRIPTION
Some elements have multiple different nested elements, and in those case
one needs to figure out which component to render for them. This helper
is a copy from the page helper, and it is small and useful.