### PR TITLE
Add support for camelCase attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ Also you have access to the `getIngredient()` and `getEssence()` methods that yo
 ```
 
 _**Note** you need to pass the data into the components `element` prop either by fetching it from the Alchemy API, by passing it from a page component (see example above) or by erb interpolation._
+
+### `camelCase` attributes
+
+This package supports `camelCase` attributes as well was `under_score` attributes.

--- a/dist/alchemy-vue.js
+++ b/dist/alchemy-vue.js
@@ -36,7 +36,7 @@ function getElementsRichtext(element, name) {
     thing = getElementsEssence(element, name) || {};
   }
 
-  return thing.sanitized_body || thing.value || thing.body;
+  return thing.sanitizedBody || thing.sanitized_body || thing.value || thing.body;
 }
 function getElementsValue(element, name) {
   var _getElementsIngredien;
@@ -114,6 +114,11 @@ var AlchemyElement = {
 var script = {
   name: "FallbackElement",
   mixins: [AlchemyElement],
+  computed: {
+    nestedElements() {
+      return this.element.nested_elements || this.element.nestedElements
+    },
+  },
 };
 
 function normalizeComponent(template, style, script, scopeId, isFunctionalTemplate, moduleIdentifier
@@ -255,17 +260,17 @@ var __vue_render__ = function() {
           ]
         : _vm._e(),
       _vm._v(" "),
-      _vm.element.nested_elements.length
+      _vm.nestedElements.length
         ? [
             _c("h3", [
               _vm._v(
-                "\n      This element has " +
-                  _vm._s(_vm.element.nested_elements.length) +
-                  " nested element(s)\n    "
+                "This element has " +
+                  _vm._s(_vm.nestedElements.length) +
+                  " nested element(s)"
               )
             ]),
             _vm._v(" "),
-            _vm._l(_vm.element.nested_elements, function(nested_element) {
+            _vm._l(_vm.nestedElements, function(nested_element) {
               return _c("FallbackElement", {
                 key: nested_element.id,
                 attrs: { element: nested_element }

--- a/src/__tests__/utilities.spec.js
+++ b/src/__tests__/utilities.spec.js
@@ -135,15 +135,36 @@ describe("Alchemy element utilities", () => {
       })
 
       describe("if ingredient with sanitized_body exists", () => {
-        it("returns the ingredients sanitized_body", () => {
-          const headline = { role: "headline", sanitized_body: "The Headline" }
-          const element = {
-            name: "article",
-            ingredients: [headline],
-          }
-          expect(getElementsRichtext(element, "headline")).toEqual(
-            "The Headline"
-          )
+        describe("with default casing", () => {
+          it("returns the ingredients sanitized_body", () => {
+            const headline = {
+              role: "headline",
+              sanitized_body: "The Headline",
+            }
+            const element = {
+              name: "article",
+              ingredients: [headline],
+            }
+            expect(getElementsRichtext(element, "headline")).toEqual(
+              "The Headline"
+            )
+          })
+        })
+
+        describe("with camel casing", () => {
+          it("returns the ingredients sanitizedBody", () => {
+            const headline = {
+              role: "headline",
+              sanitizedBody: "The Headline",
+            }
+            const element = {
+              name: "article",
+              ingredients: [headline],
+            }
+            expect(getElementsRichtext(element, "headline")).toEqual(
+              "The Headline"
+            )
+          })
         })
       })
 

--- a/src/components/FallbackElement.vue
+++ b/src/components/FallbackElement.vue
@@ -15,12 +15,10 @@
         </li>
       </ul>
     </template>
-    <template v-if="element.nested_elements.length">
-      <h3>
-        This element has {{ element.nested_elements.length }} nested element(s)
-      </h3>
+    <template v-if="nestedElements.length">
+      <h3>This element has {{ nestedElements.length }} nested element(s)</h3>
       <FallbackElement
-        v-for="nested_element in element.nested_elements"
+        v-for="nested_element in nestedElements"
         :key="nested_element.id"
         :element="nested_element"
       />
@@ -34,5 +32,10 @@
   export default {
     name: "FallbackElement",
     mixins: [AlchemyElement],
+    computed: {
+      nestedElements() {
+        return this.element.nested_elements || this.element.nestedElements
+      },
+    },
   }
 </script>

--- a/src/components/__tests__/fallback-element.spec.js
+++ b/src/components/__tests__/fallback-element.spec.js
@@ -25,7 +25,7 @@ describe("FallbackElement", () => {
   it("displays the element type", () => {
     const component = getComponent()
     expect(component.text()).toContain(
-      "I am a dummy main_header Alchemy element component",
+      "I am a dummy main_header Alchemy element component"
     )
   })
 
@@ -35,8 +35,33 @@ describe("FallbackElement", () => {
     expect(component.text()).toContain("headline")
   })
 
-  it("lists all nested elements as FallbackElement", () => {
-    const component = getComponent()
-    expect(component.findComponent(FallbackElement).exists()).toBeTruthy()
+  describe("with default casing", () => {
+    it("lists all nested elements as FallbackElement", () => {
+      const component = getComponent()
+      expect(component.findComponent(FallbackElement).exists()).toBeTruthy()
+    })
+  })
+
+  describe("with camel casing", () => {
+    it("lists all nested elements as FallbackElement", () => {
+      const component = shallowMount(FallbackElement, {
+        propsData: {
+          element: {
+            name: "main_header",
+            essences: [
+              {
+                role: "headline",
+              },
+            ],
+            nestedElements: [
+              {
+                name: "header",
+              },
+            ],
+          },
+        },
+      })
+      expect(component.findComponent(FallbackElement).exists()).toBeTruthy()
+    })
   })
 })

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -26,7 +26,9 @@ export function getElementsRichtext(element, name) {
   } else {
     thing = getElementsEssence(element, name) || {}
   }
-  return thing.sanitized_body || thing.value || thing.body
+  return (
+    thing.sanitizedBody || thing.sanitized_body || thing.value || thing.body
+  )
 }
 
 export function getElementsValue(element, name) {


### PR DESCRIPTION
Some people might use `camelCase` attributes instead of `under_score`