### PR TITLE
chore: remove vue 2 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "url": "https://github.com/AlchemyCMS/alchemy-vue/issues"
   },
   "homepage": "https://github.com/AlchemyCMS/alchemy-vue#readme",
-  "peerDependencies": {
-    "vue": "^2.x"
-  },
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.12.1",


### PR DESCRIPTION
This repository does not rely on features that have been subject to breaking changes with vue 3 so we remove the peer dependency in order to avoid installing vue 2 in projects that use this package

